### PR TITLE
fix(major): [sc-5038] Extend Deserializable interface to workaround Swift distributed actors memory leak.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,5 +40,8 @@ let package = Package(
                 .product(name: "Helpers", package: "package-concurrency-helpers"),
             ]
         ),
+        .testTarget(
+            name: "DistributedSystemConformanceTests"
+        )
     ]
 )

--- a/Sources/DistributedSystemConformance/Array+Transferable.swift
+++ b/Sources/DistributedSystemConformance/Array+Transferable.swift
@@ -87,6 +87,8 @@ public extension Array where Element: Deserializable {
             }
         }
     }
+
+    func _releaseBuffer() {}
 }
 
 extension Array: Serializable where Element: Serializable {}

--- a/Sources/DistributedSystemConformance/Dictionary+Transferable.swift
+++ b/Sources/DistributedSystemConformance/Dictionary+Transferable.swift
@@ -72,6 +72,8 @@ public extension Dictionary where Key: Deserializable, Value: Deserializable {
             self[key] = value
         }
     }
+
+    func _releaseBuffer() {}
 }
 
 extension Dictionary: Serializable where Key: Serializable, Value: Serializable {}

--- a/Sources/DistributedSystemConformance/Double+Transferable.swift
+++ b/Sources/DistributedSystemConformance/Double+Transferable.swift
@@ -25,6 +25,8 @@ public extension BinaryFloatingPoint {
         }
         self = buffer.loadUnaligned(as: Self.self)
     }
+
+    func _releaseBuffer() {}
 }
 
 extension Float: Transferable & TriviallyCopyable {}

--- a/Sources/DistributedSystemConformance/Integer+Transferable.swift
+++ b/Sources/DistributedSystemConformance/Integer+Transferable.swift
@@ -25,6 +25,8 @@ public extension BinaryInteger {
         }
         self = buffer.loadUnaligned(as: Self.self)
     }
+
+    func _releaseBuffer() {}
 }
 
 extension Int: Transferable & TriviallyCopyable {}

--- a/Sources/DistributedSystemConformance/String+Transferable.swift
+++ b/Sources/DistributedSystemConformance/String+Transferable.swift
@@ -25,6 +25,8 @@ public extension String {
             return buffer.count
         }
     }
+
+    func _releaseBuffer() {}
 }
 
 extension String: Transferable {}

--- a/Sources/DistributedSystemConformance/Transferable.swift
+++ b/Sources/DistributedSystemConformance/Transferable.swift
@@ -44,6 +44,8 @@ public protocol Deserializable {
     /// **Important:** The passed raw buffer pointer can be copied by `Self`
     /// - Parameter from: the buffer to read data from
     init(fromSerializedBuffer buffer: UnsafeRetainedRawBuffer) throws
+
+    func _releaseBuffer()
 }
 
 /// Default implementations.

--- a/Tests/DistributedSystemConformanceTests/DistributedSystemConformanceTests.swift
+++ b/Tests/DistributedSystemConformanceTests/DistributedSystemConformanceTests.swift
@@ -1,0 +1,4 @@
+import XCTest
+
+final class DistributedSystemConformanceTests: XCTestCase {
+}


### PR DESCRIPTION
## Description

Extend Deserializable interface to workaround Swift distributed actors memory leak.

## How Has This Been Tested?

Unit and manual tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
